### PR TITLE
Update links & fix breaking format change

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A dark (and light 🕯️) theme for the [Django Admin](https://docs.djangoproject.com/en/stable/ref/contrib/admin/).
 
-![Screenshot](https://github.com/sjbitcode/django-admin-dracula/blob/main/screenshot.png?raw=true)
+![Screenshot](https://github.com/dracula/django-admin/blob/main/screenshot.png?raw=true)
 
 ![PyPI](https://img.shields.io/pypi/v/django-admin-dracula?&color=%23bd93f9)
 ![PyPI downloads](https://img.shields.io/pypi/dm/django-admin-dracula?color=%23ff79c6)
@@ -37,7 +37,7 @@ Put on your favorite dracula cape and dump all your remaining garlic! 🧄
 
 ## Themes
 
-Check out some more screenshots of the light and dark themes [here](https://github.com/sjbitcode/django-admin-dracula/blob/main/THEMES.md)!
+Check out some more screenshots of the light and dark themes [here](https://github.com/dracula/django-admin/blob/main/THEMES.md)!
 
 ## Team
 

--- a/THEMES.md
+++ b/THEMES.md
@@ -2,16 +2,16 @@
 
 > A dark (and light 🕯️) theme for the [Django Admin](https://docs.djangoproject.com/en/stable/ref/contrib/admin/).
 
-![Screenshot](https://github.com/sjbitcode/django-admin-dracula/blob/main/screenshot.png?raw=true)
+![Screenshot](https://github.com/dracula/django-admin/blob/main/screenshot.png?raw=true)
 
 ## 🦇 Dark Theme
 
-![Dark theme - Admin homepage](https://github.com/sjbitcode/django-admin-dracula/blob/main/screenshots/dark-homepage.png?raw=true)
+![Dark theme - Admin homepage](https://github.com/dracula/django-admin/blob/main/screenshots/dark-homepage.png?raw=true)
 
-![Dark theme - Users homepage](https://github.com/sjbitcode/django-admin-dracula/blob/main/screenshots/dark-userspage.png?raw=true)
+![Dark theme - Users homepage](https://github.com/dracula/django-admin/blob/main/screenshots/dark-userspage.png?raw=true)
 
 ## 🕯️ Light Theme
 
-![Light theme - Admin homepage](https://github.com/sjbitcode/django-admin-dracula/blob/main/screenshots/light-homepage.png?raw=true)
+![Light theme - Admin homepage](https://github.com/dracula/django-admin/blob/main/screenshots/light-homepage.png?raw=true)
 
-![Light theme - Users homepage](https://github.com/sjbitcode/django-admin-dracula/blob/main/screenshots/light-userspage.png?raw=true)
+![Light theme - Users homepage](https://github.com/dracula/django-admin/blob/main/screenshots/light-userspage.png?raw=true)

--- a/django_admin_dracula/templates/admin/base_site.html
+++ b/django_admin_dracula/templates/admin/base_site.html
@@ -1,10 +1,12 @@
-{% extends "admin/base.html" %} {% block title %}{% if subtitle %}{{ subtitle }}
-| {% endif %}{{ title }} | {{ site_title|default:_('Django site admin') }}{%
-endblock %} {% block branding %}
-<div id="site-name">
-  <a href="{% url 'admin:index' %}"
-    >{{ site_header|default:_('Django administration') }}</a
-  >
-</div>
-{% if user.is_anonymous %} {% include "admin/color_theme_toggle.html" %} {%
-endif %} {% endblock %} {% block nav-global %}{% endblock %}
+{% extends "admin/base.html" %}
+
+{% block title %}{% if subtitle %}{{ subtitle }} | {% endif %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
+
+{% block branding %}
+<div id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></div>
+{% if user.is_anonymous %}
+  {% include "admin/color_theme_toggle.html" %}
+{% endif %}
+{% endblock %}
+
+{% block nav-global %}{% endblock %}

--- a/django_admin_dracula/templates/admin/color_theme_toggle.html
+++ b/django_admin_dracula/templates/admin/color_theme_toggle.html
@@ -1,14 +1,14 @@
 {% load i18n %}
 <button class="theme-toggle">
-  <span class="visually-hidden theme-label-when-auto"
-    >{% translate 'Toggle theme (current theme: auto)' %}</span
-  >
-  <span class="visually-hidden theme-label-when-light"
-    >{% translate 'Toggle theme (current theme: light)' %}</span
-  >
-  <span class="visually-hidden theme-label-when-dark"
-    >{% translate 'Toggle theme (current theme: dark)' %}</span
-  >
+  <span class="visually-hidden theme-label-when-auto">
+    {% translate 'Toggle theme (current theme: auto)' %}
+  </span>
+  <span class="visually-hidden theme-label-when-light">
+    {% translate 'Toggle theme (current theme: light)' %}
+  </span>
+  <span class="visually-hidden theme-label-when-dark">
+    {% translate 'Toggle theme (current theme: dark)' %}
+  </span>
   <svg aria-hidden="true" class="theme-icon-when-auto">
     <use xlink:href="#icon-auto" />
   </svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/sjbitcode/django-admin-dracula"
-Repository = "https://github.com/sjbitcode/django-admin-dracula"
-Issues = "https://github.com/sjbitcode/django-admin-dracula/issues"
+Homepage = "https://github.com/dracula/django-admin"
+Repository = "https://github.com/dracula/django-admin"
+Issues = "https://github.com/dracula/django-admin/issues"
 
 [tool.uv]
 dev-dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-admin-dracula"
-version = "0.0.3"
+version = "0.0.4"
 description = "Dracula theme for the Django admin"
 authors = [
     {name="Sangeeta Jadoonanan", email="sjbitcode@gmail.com"}


### PR DESCRIPTION
## Summary
This PR

- updates all references of the old repo url to the current repo ✨ 
- fix a format change that caused Django template tags to break (remove newline added)
- adjust another html/Django template tags format change to look a bit prettier 😅

### Breaking template tag

The previous commit added a newline within a Django template tag in `base_site.html`, thus causing an error:

<img width="1000" alt="Screenshot 2024-12-12 at 2 27 52 AM" src="https://github.com/user-attachments/assets/62b99cea-c947-4305-853e-e08c32b4c64a" />

